### PR TITLE
Change GetStatus to BroadcastStatus

### DIFF
--- a/broadcast.go
+++ b/broadcast.go
@@ -31,7 +31,7 @@ func broadcastUpdates() {
 
 		// Same Action and StatusSuccess if everyting is OK
 		res := Response{
-			Action: string(ActionGetSinks),
+			Action: string(ActionBroadcastStatus),
 			Status: StatusSuccess,
 		}
 

--- a/handleWebSocket.go
+++ b/handleWebSocket.go
@@ -72,7 +72,7 @@ func HandleWebSocket(w http.ResponseWriter, r *http.Request) {
 		}
 
 		switch msg.Action {
-		case ActionGetStatus:
+		case ActionBroadcastStatus:
 			status, _ := pactl.GetStatus()
 			res.Payload = status
 		case ActionGetSinks:

--- a/json.go
+++ b/json.go
@@ -8,7 +8,7 @@ type Action string
 
 const (
 	// Message Actions
-	ActionBroadcastStatus  Action = "BroadcastStatus"
+	ActionBroadcastStatus Action = "BroadcastStatus"
 
 	ActionGetSinks   Action = "GetSinks"
 	ActionGetCards   Action = "GetCards"

--- a/json.go
+++ b/json.go
@@ -8,7 +8,8 @@ type Action string
 
 const (
 	// Message Actions
-	ActionGetStatus  Action = "GetStatus"
+	ActionBroadcastStatus  Action = "BroadcastStatus"
+
 	ActionGetSinks   Action = "GetSinks"
 	ActionGetCards   Action = "GetCards"
 	ActionGetOutputs Action = "GetOutputs"
@@ -25,7 +26,7 @@ const (
 )
 
 var availableCommands = []Action{
-	ActionGetStatus,
+	ActionBroadcastStatus,
 	ActionGetSinks,
 	ActionGetCards,
 	ActionGetOutputs,


### PR DESCRIPTION
Fixed wrong action in broadcasting and renamed `GetStatus` to `BroadcastStatus`.
