### PR TITLE
Add build commands to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,15 +90,34 @@ test/cover:
 	go test -v -race -buildvcs -coverprofile=/tmp/coverage.out ./...
 	go tool cover -html=/tmp/coverage.out
 
+## build: get latest frontend from github and build in /tmp/bin/pr-web/dist
+.PHONY: build/fe
+build/fe:
+	rm -rf /tmp/bin/pr-web
+	git clone "https://github.com/undg/pr-web" /tmp/bin/pr-web
+	cd /tmp/bin/pr-web && \
+	pnpm install && \
+	pnpm build
+
 ## build: build the application
 .PHONY: build
-build:
+build: 
 	# Include additional build steps, like TypeScript, SCSS or Tailwind compilation here...
 	go build -ldflags=${LDFLAGS} -o=/tmp/bin/${BINARY_NAME} ${MAIN_PACKAGE_PATH}
 
-## run: run the  application
+## build: build the application together with frontend
+.PHONY: build/full
+build/full: build/fe
+	build
+
+## run: build and run the application
 .PHONY: run
 run: build
+	/tmp/bin/${BINARY_NAME}
+
+## run: build/full and run the application
+.PHONY: run/full
+run/full: build/full
 	/tmp/bin/${BINARY_NAME}
 
 ## run/watch: run the application with reloading on file changes

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ func startServer(mux *http.ServeMux) {
 		}
 	})
 
-	fs := http.FileServer(http.Dir("./frontend"))
+	fs := http.FileServer(http.Dir("/tmp/bin/pr-web/dist"))
 	mux.Handle("/", fs)
 }
 


### PR DESCRIPTION
# Frontend Integration and Build Process Enhancement

## Changes Overview

This PR introduces significant improvements to our build process and frontend integration:

1. **Frontend Build Automation**: Added a new `build/fe` target in the Makefile to fetch and build the latest frontend from the `pr-web` repository.
2. **Full Build Process**: Introduced a `build/full` target that combines backend and frontend builds.
3. **Enhanced Run Commands**: Added `run/full` command for a complete build and run process.
4. **Frontend Serving Update**: Modified the main Go file to serve the frontend from the new build location.

## Detailed Changes

### Makefile Updates

```makefile
## build: get latest frontend from github and build in /tmp/bin/pr-web/dist
.PHONY: build/fe
build/fe:
	rm -rf /tmp/bin/pr-web
	git clone "https://github.com/undg/pr-web" /tmp/bin/pr-web
	cd /tmp/bin/pr-web && \
	pnpm install && \
	pnpm build

## build: build the application together with frontend
.PHONY: build/full
build/full: build/fe
	build

## run: build/full and run the application
.PHONY: run/full
run/full: build/full
	/tmp/bin/${BINARY_NAME}
```

### Main Go File Update

```go
fs := http.FileServer(http.Dir("/tmp/bin/pr-web/dist"))
```

## Impact and Benefits

- **Streamlined Development**: Easier to manage frontend and backend changes together.
- **Consistent Builds**: Ensures that the latest frontend is always used with the backend.
- **Improved Developer Experience**: New make commands simplify the build and run process.
